### PR TITLE
Fcois v1 5 9 gamepad mode api call fix

### DIFF
--- a/FCOItemSaver/FCOItemSaver.lua
+++ b/FCOItemSaver/FCOItemSaver.lua
@@ -19,10 +19,9 @@
 -- Recomment to use libCustomMenu RegisterContextMenu
 -- Should be a following error
 
--- 4) 2019-06-18 - Bugfix - Baertram (on user report in comments, Ivo_ESO
---Research assistant duplicate items will be auto marked with FCOIS even if another researchable one was already marked
---> See file src/FCOIS_AutomaticMarks.lua, function
-
+-- 4) 2019-07-11 - Bugfix - Baertram (on user report in comments, DavidJCobb)
+--If started with GamepadMode enabled the settings of FCOIS are not loaded and the API functions will fail to work
+-->Add gamepad check to the API functions and throw an "incomatible error"
 
 ------------------------------------------------------------------
 --FCOItemSaver.lua
@@ -44,8 +43,8 @@ local FCOIS = FCOIS
 --===================== ADDON Info =============================================
 --Addon variables
 FCOIS.addonVars = {}
-FCOIS.addonVars.addonVersionOptions 		= '1.5.7' -- version shown in the settings panel
-FCOIS.addonVars.addonVersionOptionsNumber	= 1.57
+FCOIS.addonVars.addonVersionOptions 		= '1.5.8' -- version shown in the settings panel
+FCOIS.addonVars.addonVersionOptionsNumber	= 1.58
 FCOIS.addonVars.gAddonName					= "FCOItemSaver"
 FCOIS.addonVars.addonNameMenu				= "FCO ItemSaver"
 FCOIS.addonVars.addonNameMenuDisplay		= "|c00FF00FCO |cFFFF00ItemSaver|r"
@@ -77,8 +76,8 @@ function FCOIS.FCOItemSaver_CheckGamePadMode()
         if FCOIS.checkIfADCUIAndIsNotUsingGamepadMode() then
             return false
         else
-            if FCOIS.preventerVars.noGamePadMoudeSupportTextOutput == false then
-                FCOIS.preventerVars.noGamePadMoudeSupportTextOutput = true
+            if FCOIS.preventerVars.noGamePadModeSupportTextOutput == false then
+                FCOIS.preventerVars.noGamePadModeSupportTextOutput = true
                 --Normal gamepad mode is enabled -> Abort with error message "not supported!"
                 local noGamepadModeSupportedLanguageTexts = {
                     ["en"]	=	"FCO ItemSaver does not support the gamepad mode! Please change the mode to keyboard at the settings.",

--- a/FCOItemSaver/FCOItemSaver.lua
+++ b/FCOItemSaver/FCOItemSaver.lua
@@ -19,10 +19,6 @@
 -- Recomment to use libCustomMenu RegisterContextMenu
 -- Should be a following error
 
--- 4) 2019-07-11 - Bugfix - Baertram (on user report in comments, DavidJCobb)
---If started with GamepadMode enabled the settings of FCOIS are not loaded and the API functions will fail to work
--->Add gamepad check to the API functions and throw an "incomatible error"
-
 ------------------------------------------------------------------
 --FCOItemSaver.lua
 --Author: Baertram

--- a/FCOItemSaver/FCOItemSaver.lua
+++ b/FCOItemSaver/FCOItemSaver.lua
@@ -43,8 +43,8 @@ local FCOIS = FCOIS
 --===================== ADDON Info =============================================
 --Addon variables
 FCOIS.addonVars = {}
-FCOIS.addonVars.addonVersionOptions 		= '1.5.8' -- version shown in the settings panel
-FCOIS.addonVars.addonVersionOptionsNumber	= 1.58
+FCOIS.addonVars.addonVersionOptions 		= '1.5.9' -- version shown in the settings panel
+FCOIS.addonVars.addonVersionOptionsNumber	= 1.59
 FCOIS.addonVars.gAddonName					= "FCOItemSaver"
 FCOIS.addonVars.addonNameMenu				= "FCO ItemSaver"
 FCOIS.addonVars.addonNameMenuDisplay		= "|c00FF00FCO |cFFFF00ItemSaver|r"
@@ -66,8 +66,21 @@ FCOIS.addonVars.gSettingsLoaded				= false
 -- =====================================================================================================================
 --  Gamepad functions
 -- =====================================================================================================================
+function FCOIS.resetPreventerVariableAfterTime(eventRegisterName, preventerVariableName, newValue, resetAfterTimeMS)
+    local eventNameStart = "FCOIS_PreventerVariableReset_"
+    if eventRegisterName == nil or eventRegisterName == "" or preventerVariableName == nil or preventerVariableName == "" or resetAfterTimeMS == nil then return end
+    local eventName = eventNameStart .. tostring(eventRegisterName)
+    EVENT_MANAGER:UnregisterForUpdate(eventName)
+    EVENT_MANAGER:RegisterForUpdate(eventName, resetAfterTimeMS, function()
+        EVENT_MANAGER:UnregisterForUpdate(eventName)
+        if FCOIS.preventerVars == nil or FCOIS.preventerVars[preventerVariableName] == nil then return end
+        FCOIS.preventerVars[preventerVariableName] = newValue
+    end)
+end
+
 --Is the gamepad mode enabled in the ESO settings?
-function FCOIS.FCOItemSaver_CheckGamePadMode()
+function FCOIS.FCOItemSaver_CheckGamePadMode(showChatOutputOverride)
+    showChatOutputOverride = showChatOutputOverride or false
     FCOIS.preventerVars = FCOIS.preventerVars or {}
     --Gamepad enabled?
     if IsInGamepadPreferredMode() then
@@ -76,8 +89,10 @@ function FCOIS.FCOItemSaver_CheckGamePadMode()
         if FCOIS.checkIfADCUIAndIsNotUsingGamepadMode() then
             return false
         else
-            if FCOIS.preventerVars.noGamePadModeSupportTextOutput == false then
+            if showChatOutputOverride or FCOIS.preventerVars.noGamePadModeSupportTextOutput == false then
                 FCOIS.preventerVars.noGamePadModeSupportTextOutput = true
+                --Reset the anti-chat spam variable FCOIS.preventerVars.noGamePadModeSupportTextOutput again after 3 seconds
+                FCOIS.resetPreventerVariableAfterTime("noGamePadModeSupportTextOutput", "noGamePadModeSupportTextOutput", false, 3000)
                 --Normal gamepad mode is enabled -> Abort with error message "not supported!"
                 local noGamepadModeSupportedLanguageTexts = {
                     ["en"]	=	"FCO ItemSaver does not support the gamepad mode! Please change the mode to keyboard at the settings.",

--- a/FCOItemSaver/FCOItemSaver.txt
+++ b/FCOItemSaver/FCOItemSaver.txt
@@ -1,8 +1,8 @@
 ##
 ## Title: |c00FF00FCO |cFFFF00ItemSaver|r
 ## Author: Baertram
-## Version: 1.5.7
-## AddOnVersion: 157
+## Version: 1.5.9
+## AddOnVersion: 159
 ## APIVersion: 100027 100028
 ## Description: Mark/demark your inventory items with different icons and filter them in inventories, during trading, banks, guild store, mail, enchanting, crafting, researching and stores. Save your marked items before destroying/deconstructing/researching/selling/sending/trading/using or equipping/binding them!
 ## SavedVariables: FCOItemSaver_Settings

--- a/FCOItemSaver/src/FCOIS_Events.lua
+++ b/FCOItemSaver/src/FCOIS_Events.lua
@@ -728,7 +728,7 @@ local function FCOItemSaver_Player_Activated(...)
     end
 
     --Disable this addon if we are in GamePad mode
-    if not FCOIS.FCOItemSaver_CheckGamePadMode() then
+    if not FCOIS.FCOItemSaver_CheckGamePadMode(true) then
         if FCOIS.settingsVars.settings.debug then FCOIS.debugMessage( "[EVENT] Player activated", true, FCOIS_DEBUG_DEPTH_NORMAL) end
 
         --Get the currently logged in character name
@@ -786,7 +786,7 @@ local function FCOItemSaver_Loaded(eventCode, addOnName)
         if FCOIS.settingsVars.settings ~= nil and FCOIS.settingsVars.settings.debug then FCOIS.debugMessage( "[FCOIS -Event- FCOItemSaver_Loaded]", true, FCOIS_DEBUG_DEPTH_NORMAL) end
         --d("[FCOIS -Event- FCOItemSaver_Loaded]")
 
-        if not FCOIS.FCOItemSaver_CheckGamePadMode() then
+        if not FCOIS.FCOItemSaver_CheckGamePadMode(true) then
             --Unregister this event again so it isn't fired again after this addon has beend recognized
             EVENT_MANAGER:UnregisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ADD_ON_LOADED)
 

--- a/FCOItemSaver/src/FCOIS_Events.lua
+++ b/FCOItemSaver/src/FCOIS_Events.lua
@@ -786,6 +786,9 @@ local function FCOItemSaver_Loaded(eventCode, addOnName)
         if FCOIS.settingsVars.settings ~= nil and FCOIS.settingsVars.settings.debug then FCOIS.debugMessage( "[FCOIS -Event- FCOItemSaver_Loaded]", true, FCOIS_DEBUG_DEPTH_NORMAL) end
         --d("[FCOIS -Event- FCOItemSaver_Loaded]")
 
+        --Register for the zone change/player ready event
+        EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_PLAYER_ACTIVATED, FCOItemSaver_Player_Activated)
+
         if not FCOIS.FCOItemSaver_CheckGamePadMode(true) then
             --Unregister this event again so it isn't fired again after this addon has beend recognized
             EVENT_MANAGER:UnregisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ADD_ON_LOADED)
@@ -796,9 +799,6 @@ local function FCOItemSaver_Loaded(eventCode, addOnName)
 
             -- Registers addon to loadedAddon library LibLoadedAddons
             FCOIS.LIBLA:RegisterAddon(FCOIS.addonVars.gAddonName, FCOIS.addonVars.addonVersionOptionsNumber)
-
-            --Register for the zone change/player ready event
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_PLAYER_ACTIVATED, FCOItemSaver_Player_Activated)
 
             --Register for Crafting stations opened & closed (integer eventCode,number craftSkill, boolean sameStation)
             EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFTING_STATION_INTERACT, FCOItemSaver_Crafting_Interact)

--- a/FCOItemSaver/src/FCOIS_Events.lua
+++ b/FCOItemSaver/src/FCOIS_Events.lua
@@ -792,11 +792,53 @@ local function FCOItemSaver_Loaded(eventCode, addOnName)
 
             if FCOIS.settingsVars.settings.debug then FCOIS.debugMessage( "[Addon loading begins...]", true, FCOIS_DEBUG_DEPTH_NORMAL) end
             FCOIS.addonVars.gAddonLoaded = false
-
             FCOIS.preventerVars.gAddonStartupInProgress = true
 
             -- Registers addon to loadedAddon library LibLoadedAddons
             FCOIS.LIBLA:RegisterAddon(FCOIS.addonVars.gAddonName, FCOIS.addonVars.addonVersionOptionsNumber)
+
+            --Register for the zone change/player ready event
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_PLAYER_ACTIVATED, FCOItemSaver_Player_Activated)
+
+            --Register for Crafting stations opened & closed (integer eventCode,number craftSkill, boolean sameStation)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFTING_STATION_INTERACT, FCOItemSaver_Crafting_Interact)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_END_CRAFTING_STATION_INTERACT, FCOItemSaver_End_Crafting_Interact)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFT_STARTED, FCOItemSaver_Craft_Started)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFT_COMPLETED, FCOItemSaver_Craft_Completed)
+            --Register for Store opened & closed
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_STORE, function() FCOItemSaver_Open_Store("vendor") end)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_STORE, FCOItemSaver_Close_Store)
+            --Register for Trading house (guild store) opened & closed
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_TRADING_HOUSE, FCOItemSaver_Open_Trading_House)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_TRADING_HOUSE, FCOItemSaver_Close_Trading_House)
+            --Register for Guild Bank opened & closed
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_GUILD_BANK, FCOItemSaver_Open_Guild_Bank)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_GUILD_BANK, FCOItemSaver_Close_Guild_Bank)
+            --Register for Player's Bank opened & closed
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_BANK, FCOItemSaver_Open_Player_Bank)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_BANK, FCOItemSaver_Close_Player_Bank)
+            --Register for Trade panel opened & closed
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_INVITE_ACCEPTED, FCOItemSaver_Open_Trade_Panel)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_CANCELED, FCOItemSaver_Close_Trade_Panel)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_SUCCEEDED, FCOItemSaver_Close_Trade_Panel)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_FAILED, FCOItemSaver_Close_Trade_Panel)
+            --Register for player inventory slot update
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SINGLE_SLOT_UPDATE, FCOItemSaver_Inv_Single_Slot_Update)
+            EVENT_MANAGER:AddFilterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_UNIT_TAG, "player")
+            --Register the callback function for an update of the inventory slots
+            --SHARED_INVENTORY:RegisterCallback("SingleSlotInventoryUpdate", FCOItemSaver_OnSharedSingleSlotUpdate)
+            --Events for destruction & destroy prevention
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SLOT_LOCKED, FCOItemSaver_OnInventorySlotLocked)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SLOT_UNLOCKED, FCOItemSaver_OnInventorySlotUnLocked)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_MOUSE_REQUEST_DESTROY_ITEM, FCOItemSaver_OnMouseRequestDestroyItem)
+            --Event if an action layer changes
+            --EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ACTION_LAYER_POPPED, FCOItemsaver_OnActionLayerPopped)
+            --EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ACTION_LAYER_PUSHED, FCOItemsaver_OnActionLayerPushed)
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_GAME_CAMERA_UI_MODE_CHANGED, FCOItemsaver_OnGameCameraUIModeChanged)
+            --Guild bank is selected
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_GUILD_BANK_SELECTED, FCOItemsaver_SelectGuildBank)
+            --Retrait station is interacted with
+            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_RETRAIT_STATION_INTERACT_START, FCOItemsaver_RetraitStationInteract)
 
             --=============================================================================================================
             --	LOAD USER SETTINGS
@@ -862,53 +904,4 @@ function FCOIS.setEventCallbackFunctions()
     --==================================================================================================================================================================================================
     --Register the addon's loaded callback function
     EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ADD_ON_LOADED, FCOItemSaver_Loaded)
-
-    --Disable this addon if we are in GamePad mode
-    if not FCOIS.FCOItemSaver_CheckGamePadMode() then
-        --Register for the zone change/player ready event
-        EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_PLAYER_ACTIVATED, FCOItemSaver_Player_Activated)
-
-        --Do not go on if libraries are not loaded properly
-        if FCOIS.libsLoadedProperly then
-            --Register for Crafting stations opened & closed (integer eventCode,number craftSkill, boolean sameStation)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFTING_STATION_INTERACT, FCOItemSaver_Crafting_Interact)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_END_CRAFTING_STATION_INTERACT, FCOItemSaver_End_Crafting_Interact)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFT_STARTED, FCOItemSaver_Craft_Started)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CRAFT_COMPLETED, FCOItemSaver_Craft_Completed)
-            --Register for Store opened & closed
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_STORE, function() FCOItemSaver_Open_Store("vendor") end)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_STORE, FCOItemSaver_Close_Store)
-            --Register for Trading house (guild store) opened & closed
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_TRADING_HOUSE, FCOItemSaver_Open_Trading_House)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_TRADING_HOUSE, FCOItemSaver_Close_Trading_House)
-            --Register for Guild Bank opened & closed
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_GUILD_BANK, FCOItemSaver_Open_Guild_Bank)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_GUILD_BANK, FCOItemSaver_Close_Guild_Bank)
-            --Register for Player's Bank opened & closed
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_OPEN_BANK, FCOItemSaver_Open_Player_Bank)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_CLOSE_BANK, FCOItemSaver_Close_Player_Bank)
-            --Register for Trade panel opened & closed
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_INVITE_ACCEPTED, FCOItemSaver_Open_Trade_Panel)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_CANCELED, FCOItemSaver_Close_Trade_Panel)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_SUCCEEDED, FCOItemSaver_Close_Trade_Panel)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_TRADE_FAILED, FCOItemSaver_Close_Trade_Panel)
-            --Register for player inventory slot update
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SINGLE_SLOT_UPDATE, FCOItemSaver_Inv_Single_Slot_Update)
-            EVENT_MANAGER:AddFilterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_UNIT_TAG, "player")
-            --Register the callback function for an update of the inventory slots
-            --SHARED_INVENTORY:RegisterCallback("SingleSlotInventoryUpdate", FCOItemSaver_OnSharedSingleSlotUpdate)
-            --Events for destruction & destroy prevention
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SLOT_LOCKED, FCOItemSaver_OnInventorySlotLocked)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_INVENTORY_SLOT_UNLOCKED, FCOItemSaver_OnInventorySlotUnLocked)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_MOUSE_REQUEST_DESTROY_ITEM, FCOItemSaver_OnMouseRequestDestroyItem)
-            --Event if an action layer changes
-            --EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ACTION_LAYER_POPPED, FCOItemsaver_OnActionLayerPopped)
-            --EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_ACTION_LAYER_PUSHED, FCOItemsaver_OnActionLayerPushed)
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_GAME_CAMERA_UI_MODE_CHANGED, FCOItemsaver_OnGameCameraUIModeChanged)
-            --Guild bank is selected
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_GUILD_BANK_SELECTED, FCOItemsaver_SelectGuildBank)
-            --Retrait station is interacted with
-            EVENT_MANAGER:RegisterForEvent(FCOIS.addonVars.gAddonName, EVENT_RETRAIT_STATION_INTERACT_START, FCOItemsaver_RetraitStationInteract)
-        end
-    end
 end

--- a/FCOItemSaver/src/FCOIS_Settings.lua
+++ b/FCOItemSaver/src/FCOIS_Settings.lua
@@ -790,9 +790,20 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------------------------
-function FCOIS.LoadUserSettings(calledFromExternal)
+    --Check if the FCOIS settings were loaded already, or load them
+    function FCOIS.checkIfFCOISSettingsWereLoaded(calledFromExternal)
+        calledFromExternal = calledFromExternal or false
+        if not calledFromExternal or (FCOIS and FCOIS.settingsVars and FCOIS.settingsVars.settings and FCOIS.settingsVars.settings.markedItems) then return true end
+        return FCOIS.LoadUserSettings(calledFromExternal)
+    end
+
+    --Load the SavedVariables now
+    function FCOIS.LoadUserSettings(calledFromExternal)
     calledFromExternal = calledFromExternal or false
-    if calledFromExternal then FCOIS.addonVars.gSettingsLoaded = false end
+    if calledFromExternal then
+        FCOIS.addonVars.gSettingsLoaded = false
+        if FCOIS.FCOItemSaver_CheckGamePadMode() then return false end
+    end
     if not FCOIS.addonVars.gSettingsLoaded then
         --Build the default settings
         FCOIS.buildDefaultSettings()
@@ -963,6 +974,7 @@ function FCOIS.LoadUserSettings(calledFromExternal)
     end
     if calledFromExternal then FCOIS.addonVars.gSettingsLoaded = false end
     --=============================================================================================================
+    return true
 end
 
 --Copy SavedVariables from one server to another

--- a/FCOItemSaver/src/FCOIS_Settings.lua
+++ b/FCOItemSaver/src/FCOIS_Settings.lua
@@ -793,6 +793,7 @@ end
     --Check if the FCOIS settings were loaded already, or load them
     function FCOIS.checkIfFCOISSettingsWereLoaded(calledFromExternal)
         calledFromExternal = calledFromExternal or false
+--d("[FCOIS]checkIfFCOISSettingsWereLoaded-calledFromExternal: " ..tostring(calledFromExternal))
         if not calledFromExternal or (FCOIS and FCOIS.settingsVars and FCOIS.settingsVars.settings and FCOIS.settingsVars.settings.markedItems) then return true end
         return FCOIS.LoadUserSettings(calledFromExternal)
     end
@@ -800,6 +801,7 @@ end
     --Load the SavedVariables now
     function FCOIS.LoadUserSettings(calledFromExternal)
     calledFromExternal = calledFromExternal or false
+--d("[FCOIS]LoadUserSettings-calledFromExternal: " .. tostring(calledFromExternal))
     if calledFromExternal then
         FCOIS.addonVars.gSettingsLoaded = false
         if FCOIS.FCOItemSaver_CheckGamePadMode() then return false end


### PR DESCRIPTION
This addon does not support the Gamepad mode! The only possible way to use FCOIS with a gamepad is use the addon Advanced Disable Controller UI and disable the gamepad mode in it's settings. This will make the inventories etc. (using gamepad buttons sa well) work like normal keyboard inventories but the controls and movements in overland etc. will be made by the help of your gamepad.

[B]1.5.9[/B]
-The addon will show a chat message (no message spam, only once every 3 seconds) if gamepad mode is enabled and someone tries to use FCOIS or any of it's API functions. This addon does not support the gamepad mode thus the protection checks do not work properly and if any API function is called within gamepad mode it will say the item is protected or fail in other ways! 
Please be sure to check in YOUR ADDON if the gamepadmode is enabled or not before using hte FCOIS API functions. Read the description -> For developers section about it. Thank you.

